### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+composer.lock
+.idea/
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,16 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "dreamfactory/df-core": "~1.0"
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core": "~1.0.4"
+  },
+  "require-dev": {
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Security">
+            <directory>tests/Security</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Services/BaseService.php
+++ b/src/Services/BaseService.php
@@ -179,6 +179,7 @@ abstract class BaseService extends BaseRestService
     {
         if ($this->request instanceof ServiceRequestInterface) {
             $request = $this->request->toArray();
+            $request = self::redactSensitiveRequestFields($request);
 
             return [
                 'request'  => $request,
@@ -190,17 +191,75 @@ abstract class BaseService extends BaseRestService
     }
 
     /**
+     * Strip credentials and session tokens from a serialized request before
+     * it is shipped to a remote log aggregator (Logstash, Graylog, etc.).
+     *
+     * Without this, the Authorization header (Bearer JWT), the
+     * X-DreamFactory-Session-Token / X-DreamFactory-API-Key headers, the
+     * Cookie header, and the same fields under request payload / parameters
+     * would all leak to anyone with log read access — and many log
+     * aggregators retain payloads for months.
+     */
+    public static function redactSensitiveRequestFields(array $request): array
+    {
+        self::redactInPlace($request);
+        return $request;
+    }
+
+    /** @internal recursive helper for redactSensitiveRequestFields */
+    private static function redactInPlace(array &$bag): void
+    {
+        static $sensitiveKeys = [
+            'authorization',
+            'cookie',
+            'set-cookie',
+            'x-dreamfactory-session-token',
+            'x-dreamfactory-api-key',
+            'x-mcp-internal-key',
+            'session_token',
+            'api_key',
+            'password',
+            'secret',
+            'client_secret',
+            'access_token',
+            'refresh_token',
+            'id_token',
+        ];
+        foreach ($bag as $k => $v) {
+            if (is_string($k) && in_array(strtolower($k), $sensitiveKeys, true)) {
+                $bag[$k] = '***REDACTED***';
+            } elseif (is_array($v)) {
+                self::redactInPlace($bag[$k]);
+            }
+        }
+    }
+
+    /**
      * @return array
      */
     public function getPlatformInfo()
     {
+        // Curated allowlist instead of the full df.* config tree (which
+        // includes DB connection strings, encryption keys, mail creds).
         $platform = [
-            'config'  => Config::get('df'),
+            'config'  => [
+                'version'      => Config::get('df.version'),
+                'api_version'  => Config::get('df.api_version'),
+                'license'      => Config::get('df.license'),
+                'is_managed'   => to_bool(env('DF_MANAGED', false)),
+            ],
             'session' => Session::all(),
         ];
 
-        unset($platform['session']['lookup']);
-        unset($platform['session']['lookup_secret']);
+        // Strip auth-bearing fields from the session payload before logging.
+        $sessionRedactKeys = [
+            'lookup', 'lookup_secret',
+            'session_token', 'api_key', 'jwt',
+            'token', 'access_token', 'refresh_token',
+        ];
+        foreach ($sessionRedactKeys as $k) {
+            unset($platform['session'][$k]);
+        }
 
         return $platform;
     }

--- a/tests/Security/SensitiveRedactionTest.php
+++ b/tests/Security/SensitiveRedactionTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace DreamFactory\Core\Logger\Tests\Security;
+
+use DreamFactory\Core\Logger\Services\BaseService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: BaseService must redact credential-bearing headers and fields
+ * from log payloads sent to remote aggregators (Logstash/Graylog/etc.).
+ */
+class SensitiveRedactionTest extends TestCase
+{
+    public function testAuthorizationHeaderRedacted(): void
+    {
+        $request = [
+            'headers' => [
+                'authorization' => 'Bearer abc.def.ghi',
+                'host'          => 'localhost',
+            ],
+        ];
+        $out = BaseService::redactSensitiveRequestFields($request);
+        $this->assertSame('***REDACTED***', $out['headers']['authorization']);
+        $this->assertSame('localhost', $out['headers']['host']);
+    }
+
+    public function testApiKeyAndSessionTokenHeaderRedacted(): void
+    {
+        $request = [
+            'headers' => [
+                'x-dreamfactory-session-token' => 'eyJ...',
+                'x-dreamfactory-api-key'       => 'abc',
+                'x-mcp-internal-key'           => 'secret',
+                'cookie'                       => 'session=foo',
+            ],
+        ];
+        $out = BaseService::redactSensitiveRequestFields($request);
+        foreach (['x-dreamfactory-session-token', 'x-dreamfactory-api-key', 'x-mcp-internal-key', 'cookie'] as $h) {
+            $this->assertSame('***REDACTED***', $out['headers'][$h], "Header {$h} should be redacted");
+        }
+    }
+
+    public function testNestedPayloadCredentialsRedacted(): void
+    {
+        $request = [
+            'payload' => [
+                'username'      => 'alice',
+                'password'      => 'hunter2',
+                'access_token'  => 'tok',
+            ],
+            'parameters' => [
+                'session_token' => 'eyJ...',
+                'limit'         => 10,
+            ],
+        ];
+        $out = BaseService::redactSensitiveRequestFields($request);
+        $this->assertSame('alice', $out['payload']['username']);
+        $this->assertSame('***REDACTED***', $out['payload']['password']);
+        $this->assertSame('***REDACTED***', $out['payload']['access_token']);
+        $this->assertSame('***REDACTED***', $out['parameters']['session_token']);
+        $this->assertSame(10, $out['parameters']['limit']);
+    }
+
+    public function testRedactionIsCaseInsensitive(): void
+    {
+        $request = ['headers' => ['Authorization' => 'Bearer x', 'COOKIE' => 'session=foo']];
+        $out = BaseService::redactSensitiveRequestFields($request);
+        $this->assertSame('***REDACTED***', $out['headers']['Authorization']);
+        $this->assertSame('***REDACTED***', $out['headers']['COOKIE']);
+    }
+}


### PR DESCRIPTION
## Release prep: cut develop into master/main

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

### Verification

The develop HEAD on this branch is the SHA locked into the L13/PHP 8.5
test bundle that the team has been smoking. **Full end-to-end smoke
passed 2026-05-26**: PHP 8.5.5, Laravel 13.11.2, `df:setup` seeders,
admin login → JWT, service-type registration (81 types), Postgres
schema introspection + CRUD, OpenAPI generation.

### Coordinated release PRs

This is one of ~26 coordinated `develop → master/main` PRs opened
together as the release cut. Suggested merge order:

1. **Foundation**: df-core → df-system → df-user → df-database
2. **Connectors**: df-sqldb, df-sqlsrv, df-mongodb, df-oracledb, df-snowflake, df-soap, df-salesforce, df-script
3. **Auth**: df-oauth → df-adldap, df-azure-ad, df-oidc, df-saml
4. **Services**: df-email, df-file, df-cache, df-limits, df-logger, df-scheduler
5. **AI tier**: df-ai → df-ai-chat → df-mcp-server
6. **Admin UI**: df-admin-interface
7. **Host app**: dreamfactory/dreamfactory (released last)

### Customer upgrade path

In-place on Docker / managed Linux packages; blue-green strongly
recommended on Windows + custom-PHP-extension installs. Pre-flight
checklist in the release notes.
